### PR TITLE
Makefile: allow overriding CC and CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC         := gcc
-CFLAGS     := -O3 -Wall -fomit-frame-pointer
+CC         ?= gcc
+CFLAGS     ?= -O3 -Wall -fomit-frame-pointer
 
 all: mhz
 


### PR DESCRIPTION
For OpenWrt and Buildroot which support really large amount of different architectures and cores it is sometimes required to pass our own CFLAGS. This is especially true if hardening options are to be respected.

Also, for cross-compiling CC should be respected as currently it is working since both OpenWrt and Buildroot symlink gcc to the cross compiler.

So, lets set the current values as defaults but allow them to be overriden.